### PR TITLE
Add check for null in countCommitsSince

### DIFF
--- a/src/main/java/org/unbrokendome/gradle/plugins/gitversion/internal/GitOperations.java
+++ b/src/main/java/org/unbrokendome/gradle/plugins/gitversion/internal/GitOperations.java
@@ -118,7 +118,7 @@ public class GitOperations {
 
     public int countCommitsSince(HasObjectId obj, boolean countMergeCommits) {
         GitCommit head = repository.getHead();
-        if (head != null) {
+        if (obj != null && head != null) {
             ReachableCommitSet commitSet = new ReachableCommitSet(head, countMergeCommits);
             do {
                 if (commitSet.contains(obj)) {

--- a/src/test/groovy/org/unbrokendome/gradle/plugins/gitversion/internal/GitOperationsTest.groovy
+++ b/src/test/groovy/org/unbrokendome/gradle/plugins/gitversion/internal/GitOperationsTest.groovy
@@ -115,6 +115,22 @@ class GitOperationsTest extends Specification {
     /*
      * A --> B --> C     (master, HEAD)
      */
+    def "branchPoint without a branch point (returns null)"() {
+        given:
+            def repository = MockGitRepository.builder()
+                    .commit('A')
+                    .commit('B')
+                    .commit('C')
+                    .build()
+            when:
+                def branchPoint = new GitOperations(repository).branchPoint("develop")
+            then:
+                branchPoint == null
+    }
+
+    /*
+     * A --> B --> C     (master, HEAD)
+     */
     def "countCommitsSince simple case"() {
         given:
             def repository = MockGitRepository.builder()
@@ -156,6 +172,21 @@ class GitOperationsTest extends Specification {
             countingMergeCommits | expectedCount
             true                 | 2
             false                | 1
+    }
+
+    def "countCommitsSince branchPoint without branch point"() {
+        given:
+            def repository = MockGitRepository.builder()
+                .commit('A')
+                .commit('B')
+                .commit('C')
+                .build()
+        when:
+            def gitOps = new GitOperations(repository)
+            def branchPoint = gitOps.branchPoint("develop")
+            def count = gitOps.countCommitsSince(branchPoint, false)
+        then:
+            count == -1
     }
 
     /*


### PR DESCRIPTION
  ...because e.g. `branchPoint()` may return `null`. 

This can happen if we're on a branch from where a `branchPoint` cannot be determined. In that case, the `branchPoint()` method may return `null` which leads to a `NullPointerException` if used together with `countCommitsSince(branchPoint("origin/develop"))`. 